### PR TITLE
Use `xcode-select -p` as a base path to `xcode-git`

### DIFF
--- a/git
+++ b/git
@@ -29,5 +29,5 @@ for var in "$@"; do
 	fi
 done
 
-DIR=$(dirname $0)
-"$DIR"/xcode-git "${ARGS[@]}"
+XCODE_BIN_DIR="`xcode-select -p`/usr/bin"
+"$XCODE_BIN_DIR"/xcode-git "${ARGS[@]}"


### PR DESCRIPTION
The `git` script assumed it was always run from `<Xcode dir>/usr/bin` and as such used `$(dirname $0)` as a base path to point to the original Xcode git binary.

However, that's not always the case as there are other places that symlink to Xcode's `/usr/bin/git`, like
`<Xcode dir>/usr/libexec/git-core/git`, meaning that any operation that used these links would fail.

By using the `xcode-select -p` path as a base path to the Xcode directory this is fixed.

PS: Thanks for making this! 🙌 